### PR TITLE
When loading the page, displaying the availability set form DB

### DIFF
--- a/client/src/pages/WorkSpaceDetail.js
+++ b/client/src/pages/WorkSpaceDetail.js
@@ -216,6 +216,7 @@ class WorkSpaceDetail extends Component {
     API.getWorkSpaceById(this.props.match.params.id)
       .then(res => {
         let fetchedWorkSpaceDetail = res.data[0];
+        let availabilityArray = fetchedWorkSpaceDetail.WorkspaceAvailabilities;
         this.setState({
           workSpaceId: parseInt(fetchedWorkSpaceDetail.id),
           workSpaceName: fetchedWorkSpaceDetail.name,
@@ -226,7 +227,9 @@ class WorkSpaceDetail extends Component {
           workSpaceOccupancy: fetchedWorkSpaceDetail.no_occupants,
           workSpaceDimensions: fetchedWorkSpaceDetail.dimension,
           workSpaceDailyRate: fetchedWorkSpaceDetail.rental_price,
-          activateWorkSpace: fetchedWorkSpaceDetail.isActive
+          activateWorkSpace: fetchedWorkSpaceDetail.isActive,
+          startDate: moment(availabilityArray[0].date),
+          endDate: moment(availabilityArray[availabilityArray.length - 1].date)
         });
         this.loadFeaturesForWorkSpace(fetchedWorkSpaceDetail.Features);
         let ownerId = fetchedWorkSpaceDetail.WorkspaceLocation.UserId;


### PR DESCRIPTION
If a workspace has availability already set by the user, it should show those dates when page loads