### PR TITLE
Fixing initial loading of owner locations

### DIFF
--- a/client/src/pages/WorkSpaceDetail.js
+++ b/client/src/pages/WorkSpaceDetail.js
@@ -307,7 +307,7 @@ class WorkSpaceDetail extends Component {
       this.loadWorkSpaceDetails();
     } else {
       this.loadFeaturesForWorkSpace();
-      this.loadLocationsByOwner(OWNER_ID);
+      this.loadLocationsByOwner(localStorage.getItem("UserId"));
     }
   };
 


### PR DESCRIPTION
The `OWNER_ID` was defined outside class, and hence loads during application launch.
At that time user would not be logged in and hence unable to fetch Locations for the owner

Fixing thsi